### PR TITLE
Remove json from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ pymisp
 httplib2>=0.8
 configparser
 urllib3
-json
 http
 nose


### PR DESCRIPTION
Install will halt with "Could not find a version that satisfies the requirement json" in Python 2.7 otherwise