### PR TITLE
Fixed typo with proxy protocol setting

### DIFF
--- a/config.example.cfg
+++ b/config.example.cfg
@@ -15,7 +15,7 @@ last_hours=48
 use_proxy=False
 port=8080
 host=
-protocoll=https
+protocol=https
 full=https://yourproxy:8080
 
 [general]


### PR DESCRIPTION
Fixes issue related to "protocol" setting not being found in config file when using a proxy:

Traceback (most recent call last):
  File "test_pysight.py", line 3, in <module>
    import PySight_settings
  File "/PySight/PySight2MISP/PySight_settings.py", line 47, in <module>
    PROXY_PROTOCOL = config.get('proxy', 'protocol')
  File "/usr/lib64/python3.6/configparser.py", line 792, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'protocol' in section: 'proxy'

When using a proxy, PySight_settings.py will throw a NoOptionError, due to the setting "protocol" being incorrectly spelled as "protocoll" in the example config file.